### PR TITLE
Changed Basemap to Ordnance Survey in the example

### DIFF
--- a/examples/browser_example.html
+++ b/examples/browser_example.html
@@ -102,7 +102,7 @@
     {
       maxZoom: 19,
       attribution:
-        'Contains OS data &copy Crown copyright and database rights 2022',
+        'Contains OS data &copy Crown copyright and database rights ' + new Date().getFullYear(),
     }
   );
   const featureLayer = L.geoJSON([]);

--- a/examples/browser_example.html
+++ b/examples/browser_example.html
@@ -98,11 +98,11 @@
   );
   new L.Control.Zoom({ position: "bottomright" }).addTo(map);
   const tileLayer = L.tileLayer(
-    "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
+    "https://api.os.uk/maps/raster/v1/zxy/Light_3857/{z}/{x}/{y}.png?key=sks1ArFMuYctiVGbAmt8GtRSIuFeCV2Y",
     {
       maxZoom: 19,
       attribution:
-        '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+        'Contains OS data &copy Crown copyright and database rights 2022',
     }
   );
   const featureLayer = L.geoJSON([]);


### PR DESCRIPTION
Fixed Issue #51, where the basemap in the browser example is osm. The API key in plain text is locked down to the specific github url so it shouldn't be a security issue.